### PR TITLE
Add in-game population control settings GUI

### DIFF
--- a/PopulationControl/common/decisions/PopulationControl_Decisions.txt
+++ b/PopulationControl/common/decisions/PopulationControl_Decisions.txt
@@ -8,13 +8,21 @@
 			exists = global_var:Population_Control_On
 		}
 	}
-	effect = {
-		custom_tooltip = Start_Population_Control_Decision_effect_tooltip
-		set_global_variable = {
-			name = Population_Control_On
-			value = 1
-		}
-	}
+        effect = {
+                custom_tooltip = Start_Population_Control_Decision_effect_tooltip
+                set_global_variable = {
+                        name = Population_Control_On
+                        value = 1
+                }
+                set_global_variable = {
+                        name = maintain_population_min
+                        value = 20000
+                }
+                set_global_variable = {
+                        name = maintain_population_max
+                        value = 22500
+                }
+        }
 	ai_check_interval = 0
 	ai_will_do = {
 		base=0

--- a/PopulationControl/common/decisions/PopulationControl_Settings_Decision.txt
+++ b/PopulationControl/common/decisions/PopulationControl_Settings_Decision.txt
@@ -1,0 +1,15 @@
+PopulationControl_Open_Settings = {
+        picture = {
+                reference = "gfx/interface/illustrations/decisions/decision_major_religion.dds"
+        }
+        decision_group_type = decisions
+        major = yes
+        is_shown = { always = yes }
+        effect = {
+                trigger_event = { id = Population_Control.settings.1 }
+        }
+        ai_check_interval = 0
+        ai_will_do = {
+                base=0
+        }
+}

--- a/PopulationControl/events/PopulationControl_Event.txt
+++ b/PopulationControl/events/PopulationControl_Event.txt
@@ -7,9 +7,9 @@ Population_Control.0001 = {
 
 	trigger = {
 		OR = {
-			any_living_character = {				
-				count >= maintain_population_max			
-			}
+                       any_living_character = {
+                               count >= global_var:maintain_population_max
+                       }
 			exists = global_var:wipestart	
 		}
 	}
@@ -24,9 +24,9 @@ Population_Control.0001 = {
 		}
 		if = {
 			limit= {
-				any_living_character = {				
-					count <= maintain_population_min			
-				}	
+                               any_living_character = {
+                                       count <= global_var:maintain_population_min
+                               }
 			}		
 			remove_global_variable = wipestart				
 		}

--- a/PopulationControl/events/PopulationControl_settings_events.txt
+++ b/PopulationControl/events/PopulationControl_settings_events.txt
@@ -1,0 +1,15 @@
+event = {
+        id = Population_Control.settings.1
+        hide_window = yes
+        immediate = {
+                if = {
+                        limit = { NOT = { exists = global_var:maintain_population_min } }
+                        set_global_variable = { name = maintain_population_min value = 20000 }
+                }
+                if = {
+                        limit = { NOT = { exists = global_var:maintain_population_max } }
+                        set_global_variable = { name = maintain_population_max value = 22500 }
+                }
+                show_interface = { interface = PopulationControl_settings_window }
+        }
+}

--- a/PopulationControl/gui/PopulationControl_settings.gui
+++ b/PopulationControl/gui/PopulationControl_settings.gui
@@ -1,0 +1,33 @@
+guiTypes = {
+    containerWindowType = {
+        name = "PopulationControl_settings_window"
+        size = { x = 400 y = 150 }
+        layer = game
+        draggable = yes
+
+        children = {
+            slider = {
+                name = "maintain_min_slider"
+                position = { x = 20 y = 40 }
+                range = { min = 0 max = 100000 }
+                tooltip = "PC_SETTING_MIN_TOOLTIP"
+                value = "[GlobalVariableInt('maintain_population_min')]"
+                on_value_changed = "PC_on_min_slider_change"
+            }
+            slider = {
+                name = "maintain_max_slider"
+                position = { x = 20 y = 80 }
+                range = { min = 0 max = 100000 }
+                tooltip = "PC_SETTING_MAX_TOOLTIP"
+                value = "[GlobalVariableInt('maintain_population_max')]"
+                on_value_changed = "PC_on_max_slider_change"
+            }
+            button = {
+                name = "close_button"
+                position = { x = 150 y = 120 }
+                text = "PC_CLOSE"
+                on_click = "PC_close_settings_window"
+            }
+        }
+    }
+}

--- a/PopulationControl/gui/PopulationControl_settings.gui_script
+++ b/PopulationControl/gui/PopulationControl_settings.gui_script
@@ -1,0 +1,11 @@
+PC_on_min_slider_change = {
+    gui_scope:SetGlobalVariable( 'maintain_population_min', GuiValue )
+}
+
+PC_on_max_slider_change = {
+    gui_scope:SetGlobalVariable( 'maintain_population_max', GuiValue )
+}
+
+PC_close_settings_window = {
+    Gui.Hide( 'PopulationControl_settings_window' )
+}

--- a/PopulationControl/localization/english/PopulationControl_settings_l_english.yml
+++ b/PopulationControl/localization/english/PopulationControl_settings_l_english.yml
@@ -1,0 +1,8 @@
+l_english:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/french/PopulationControl_settings_l_french.yml
+++ b/PopulationControl/localization/french/PopulationControl_settings_l_french.yml
@@ -1,0 +1,8 @@
+l_french:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/german/PopulationControl_settings_l_german.yml
+++ b/PopulationControl/localization/german/PopulationControl_settings_l_german.yml
@@ -1,0 +1,8 @@
+l_german:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/korean/PopulationControl_settings_l_korean.yml
+++ b/PopulationControl/localization/korean/PopulationControl_settings_l_korean.yml
@@ -1,0 +1,8 @@
+l_korean:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/polish/PopulationControl_settings_l_polish.yml
+++ b/PopulationControl/localization/polish/PopulationControl_settings_l_polish.yml
@@ -1,0 +1,8 @@
+l_polish:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/russian/PopulationControl_settings_l_russian.yml
+++ b/PopulationControl/localization/russian/PopulationControl_settings_l_russian.yml
@@ -1,0 +1,8 @@
+l_russian:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/simp_chinese/PopulationControl_settings_l_simp_chinese.yml
+++ b/PopulationControl/localization/simp_chinese/PopulationControl_settings_l_simp_chinese.yml
@@ -1,0 +1,8 @@
+l_simp_chinese:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"

--- a/PopulationControl/localization/spanish/PopulationControl_settings_l_spanish.yml
+++ b/PopulationControl/localization/spanish/PopulationControl_settings_l_spanish.yml
@@ -1,0 +1,8 @@
+l_spanish:
+ PopulationControl_Open_Settings:0 "Population Control Settings"
+ PopulationControl_Open_Settings_desc:0 "Adjust Population Control parameters."
+ PopulationControl_Open_Settings_confirm:0 "Open Settings"
+ PopulationControl_Open_Settings_tooltip:0 "Open the Population Control settings window."
+ PC_SETTING_MIN_TOOLTIP:0 "Minimum population to maintain"
+ PC_SETTING_MAX_TOOLTIP:0 "Maximum population to maintain"
+ PC_CLOSE:0 "Close"


### PR DESCRIPTION
## Summary
- add decision and event to open a population control settings window
- introduce sliders to set minimum and maximum population thresholds in-game
- initialize and use global variables instead of script values for these thresholds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a827d3ac28832999a8ee0cd1c668e6